### PR TITLE
PHP-2: Create base drush command

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-User story: [TC22-XX: Story name](https://palantir.atlassian.net/browse/TC22-XX)
+User story: [PHP-XX: Story name](https://palantir.atlassian.net/browse/PHP-XX)
 
 ### Description
 

--- a/drush.services.yml
+++ b/drush.services.yml
@@ -3,3 +3,4 @@ services:
     class: \Drupal\tester\Commands\TesterCommands
     tags:
       - { name: drush.command }
+    arguments: ['@config.factory', '@http_client', '@state']

--- a/src/Commands/TesterCommands.php
+++ b/src/Commands/TesterCommands.php
@@ -3,11 +3,45 @@
 namespace Drupal\tester\Commands;
 
 use Drush\Commands\DrushCommands;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\State\StateInterface;
+use GuzzleHttp\Client;
 
 /**
  * Defines the class for our drush commands.
  */
 class TesterCommands extends DrushCommands {
+
+  /**
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * @var \GuzzleHttp\Client
+   */
+  protected $httpClient;
+
+  /**
+   * @var \Drupal\Core\State\StateInterface
+   */
+  protected $state;
+
+  /**
+   * Constructs the class.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory service.
+   * @param \GuzzleHttp\Client $http_client
+   *   The default http client.
+   * @param \Drupal\Core\State\StateInterface $state
+   *   The state interface
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, Client $http_client, StateInterface $state) {
+    $this->configFactory = $config_factory;
+    $this->httpClient = $http_client;
+    $this->state = $state;
+  }
 
   /**
    * Test function.

--- a/src/Commands/TesterCommands.php
+++ b/src/Commands/TesterCommands.php
@@ -23,15 +23,18 @@ class TesterCommands extends DrushCommands {
   /**
    * Crawls a site looking for errors.
    *
+   * @param string $base_url
+   *   The base URL to use when crawling the site. No trailing slash.
+   *
    * @command tester:crawl
    * @aliases tester-crawl, tc
    * @usage drush tester:crawl, drush tc
    */
-  public function crawl() {
+  public function crawl($base_url) {
     $urls = $this->getUrls();
-    echo "Crawling URLS\n";
+    echo "Crawling URLs\n";
     foreach ($urls as $url) {
-      echo "• $url\n";
+      echo " • $base_url$url\n";
     }
   }
 
@@ -45,8 +48,8 @@ class TesterCommands extends DrushCommands {
     // @todo Use the plugin system. https://palantir.atlassian.net/browse/PHP-3
     return [
       '/',
-      'admin',
-      'foo-bar',
+      '/admin',
+      '/foo-bar',
     ];
   }
 

--- a/src/Commands/TesterCommands.php
+++ b/src/Commands/TesterCommands.php
@@ -72,9 +72,13 @@ class TesterCommands extends DrushCommands {
     if (is_null($base_url)) {
       GLOBAL $base_url;
     }
+
     $urls = $this->getUrls();
+
     // We want to test 403 and 404 pages, so allow them.
     // See https://docs.guzzlephp.org/en/stable/request-options.html#http-errors
+    // We also do some status reporting.
+    // See https://docs.guzzlephp.org/en/stable/request-options.html#on-stats
     $options = [
       'http_errors' => FALSE,
       'on_stats' => function (TransferStats $stats) {

--- a/src/Commands/TesterCommands.php
+++ b/src/Commands/TesterCommands.php
@@ -25,12 +25,16 @@ class TesterCommands extends DrushCommands {
    *
    * @param string $base_url
    *   The base URL to use when crawling the site. No trailing slash.
+   *   If not provided, the global $base_url value will be used.
    *
    * @command tester:crawl
    * @aliases tester-crawl, tc
    * @usage drush tester:crawl, drush tc
    */
-  public function crawl($base_url) {
+  public function crawl($base_url = NULL) {
+    if (is_null($base_url)) {
+      GLOBAL $base_url;
+    }
     $urls = $this->getUrls();
     echo "Crawling URLs\n";
     foreach ($urls as $url) {

--- a/src/Commands/TesterCommands.php
+++ b/src/Commands/TesterCommands.php
@@ -28,7 +28,26 @@ class TesterCommands extends DrushCommands {
    * @usage drush tester:crawl, drush tc
    */
   public function crawl() {
-    echo "Hello World\n";
+    $urls = $this->getUrls();
+    echo "Crawling URLS\n";
+    foreach ($urls as $url) {
+      echo "• $url\n";
+    }
+  }
+
+  /**
+   * Retrieves the list of URLs to test.
+   *
+   * @return array
+   *   An array of URLs.
+   */
+  private function getUrls() {
+    // @todo Use the plugin system. https://palantir.atlassian.net/browse/PHP-3
+    return [
+      '/',
+      'admin',
+      'foo-bar',
+    ];
   }
 
 }

--- a/src/Commands/TesterCommands.php
+++ b/src/Commands/TesterCommands.php
@@ -17,7 +17,18 @@ class TesterCommands extends DrushCommands {
    * @usage drush tester:test
    */
   public function test() {
-    echo "Hello World";
+    echo "Hello World\n";
+  }
+
+  /**
+   * Crawls a site looking for errors.
+   *
+   * @command tester:crawl
+   * @aliases tester-crawl, tc
+   * @usage drush tester:crawl, drush tc
+   */
+  public function crawl() {
+    echo "Hello World\n";
   }
 
 }


### PR DESCRIPTION
User story: [PHP-2: Create base drush command](https://palantir.atlassian.net/browse/PHP-2)

### Description

- Adds a simple URL fetcher to the module for testing.

### Testing instructions

1. Checkout this branch
1. Run `drush cr`
2. Run `drush tc`

It should return something like so:

```
Crawling URLs
 • https://domain.ddev.site/
  - Status: 200
 • https://domain.ddev.site/admin
  - Status: 403
 • https://domain.ddev.site/foo-bar
  - Status: 404
```

Where the URL base will vary based on your site.