### PR TITLE
PHP-18: Setup and teardown tasks

### DIFF
--- a/drush.services.yml
+++ b/drush.services.yml
@@ -3,4 +3,4 @@ services:
     class: \Drupal\tester\Commands\TesterCommands
     tags:
       - { name: drush.command }
-    arguments: ['@plugin.manager.tester', '@module_handler', '@http_client', '@config.factory', '@state']
+    arguments: ['@plugin.manager.tester', '@module_handler', '@module_installer', '@http_client', '@config.factory', '@state']

--- a/src/Commands/TesterCommands.php
+++ b/src/Commands/TesterCommands.php
@@ -85,6 +85,7 @@ class TesterCommands extends DrushCommands {
    * @usage drush tester:crawl, drush tc
    */
   public function crawl($base_url = NULL) {
+    $this->setUp();
     echo "Crawling URLs\n";
 
     if (is_null($base_url)) {
@@ -114,6 +115,8 @@ class TesterCommands extends DrushCommands {
         $this->httpClient->request('GET', $path, $options);
       }
     }
+
+    $this->tearDown();
   }
 
   /**
@@ -163,6 +166,23 @@ class TesterCommands extends DrushCommands {
       }
     }
     return $return;
+  }
+
+  /**
+   * Sets up the crawler run by changing application state.
+   *
+   * We want dblog enabled and full error reporting. When finished, we will
+   * set those back.
+   */
+  private function setUp() {
+
+  }
+
+  /**
+   * Tears down the crawler run by changing application state.
+   */
+  private function tearDown() {
+
   }
 
 }

--- a/src/Commands/TesterCommands.php
+++ b/src/Commands/TesterCommands.php
@@ -6,6 +6,7 @@ use Drupal\tester\TesterPluginManager;
 use Drush\Commands\DrushCommands;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Extension\ModuleInstallerInterface;
 use Drupal\Core\State\StateInterface;
 use GuzzleHttp\Client;
 use GuzzleHttp\TransferStats;
@@ -24,6 +25,11 @@ class TesterCommands extends DrushCommands {
    * @var \Drupal\Core\Extension\ModuleHandlerInterface
    */
   protected $moduleHandler;
+
+  /**
+   * @var \Drupal\Core\Extension\ModuleInstallerInterface
+   */
+  protected $moduleInstaller;
 
   /**
    * @var \Drupal\Core\Config\ConfigFactoryInterface
@@ -47,6 +53,8 @@ class TesterCommands extends DrushCommands {
    *   The tester plugin manager.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
    *   The module handler.
+   * @param \Drupal\Core\Extension\ModuleInstallerInterface $module_installer
+   *   The module installer.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The config factory service.
    * @param \GuzzleHttp\Client $http_client
@@ -54,9 +62,10 @@ class TesterCommands extends DrushCommands {
    * @param \Drupal\Core\State\StateInterface $state
    *   The state interface
    */
-  public function __construct(TesterPluginManager $plugin_manager, ModuleHandlerInterface $module_handler, Client $http_client, ConfigFactoryInterface $config_factory, StateInterface $state) {
+  public function __construct(TesterPluginManager $plugin_manager, ModuleHandlerInterface $module_handler, ModuleInstallerInterface $module_installer, Client $http_client, ConfigFactoryInterface $config_factory, StateInterface $state) {
     $this->pluginManager = $plugin_manager;
     $this->moduleHandler = $module_handler;
+    $this->moduleInstaller = $module_installer;
     $this->configFactory = $config_factory;
     $this->httpClient = $http_client;
     $this->state = $state;
@@ -175,14 +184,48 @@ class TesterCommands extends DrushCommands {
    * set those back.
    */
   private function setUp() {
+    $state_change = [
+      'error_level' => NULL,
+      'dblog' => FALSE,
+    ];
 
+    // Set up error logging to highest level.
+    $config = $this->configFactory->getEditable('system.logging');
+    $error_level = $config->get('error_level');
+    if ($error_level !== "all") {
+      $config->set('error_level', 'all')->save();
+      $state_change['error_level'] = $error_level;
+    }
+
+    // Ensure dblog is enabled.
+    if (!$this->moduleHandler->moduleExists("dblog")) {
+      $this->moduleInstaller->install(['dblog']);
+      $state_change['dblog'] = TRUE;
+    }
+
+    // Set values in state.
+    $this->state->set('tester', $state_change);
   }
 
   /**
    * Tears down the crawler run by changing application state.
    */
   private function tearDown() {
+    $state_change = $this->state->get('tester');
 
+    // Reset error reporting.
+    if (!is_null($state_change['error_level'])) {
+      $config = $this->configFactory->getEditable('system.logging');
+      $config->set('error_level', $state_change['error_level'])->save();
+    }
+
+    // Reset dblog.
+    if ($state_change['dblog']) {
+      $this->moduleInstaller->uninstall(['dblog']);
+    }
+
+    // Clear state.
+    $this->state->delete('tester');
   }
 
 }

--- a/src/Plugin/Tester/SystemTester.php
+++ b/src/Plugin/Tester/SystemTester.php
@@ -15,6 +15,9 @@ use Drupal\tester\Plugin\TesterPluginInterface;
  */
 class SystemTester extends PluginBase implements TesterPluginInterface {
 
+  /**
+   * {@inheritdoc}
+   */
   public function urls() {
     return [
       '/',
@@ -23,6 +26,9 @@ class SystemTester extends PluginBase implements TesterPluginInterface {
     ];
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function dependencies() {
     return [
       'modules' => [


### PR DESCRIPTION
User story: [PHP-18: Setup and teardown tasks](https://palantir.atlassian.net/browse/PHP-18)

### Description

Ensures we enable what we need and then clean up after ourselves.


### Testing instructions

* Disable dblog (`drush pmu dblog`)
* Run `drush tc` -- if should enable and then disable dblog
* Ensure dblog is still disabled
* Enable tester_error_generator module (`ddev en tester_error_generator`)
* Go to /admin/config/development/logging and set error level to "None"
* Enable dblog 
* Run `drush tc`
* Visit admin/reports/dblog and confirm errors are logged
* Go to /admin/config/development/logging and confirm error level is set to "None"
