### PR TITLE
PHP-5: Format error reports

### DIFF
--- a/src/Commands/TesterCommands.php
+++ b/src/Commands/TesterCommands.php
@@ -271,14 +271,17 @@ class TesterCommands extends DrushCommands {
    */
   protected function getErrors(int $count, int $initial) {
     $errors = [];
+    // We cannot filter by type accurately?
     $query = $this->database->select('watchdog', 'w')
-      ->fields('w', ['wid', 'message', 'variables'])
+      ->fields('w', ['wid', 'message', 'variables', 'type'])
       ->orderBy('wid', 'ASC')
       ->range($initial, $count);
     $result = $query->execute();
 
     foreach ($result as $dblog) {
-      $errors[$dblog->wid] = $this->formatMessage($dblog);
+      if ($dblog->type === 'php') {
+        $errors[$dblog->wid] = $this->formatMessage($dblog);
+      }
     }
 
     return $errors;
@@ -344,6 +347,7 @@ class TesterCommands extends DrushCommands {
   protected function getWatchdogCount() {
     $query = $this->database->select('watchdog', 'w')
       ->fields('w', ['wid'])
+      ->condition('w.type', 'php')
       ->orderBy('wid', 'DESC')
       ->range(0, 1);
     return $query->execute()->fetchField();


### PR DESCRIPTION
User story: [PHP-5: Format error reports](https://palantir.atlassian.net/browse/PHP-5)

### Description

Outputs results in human-readable format.

### Testing instructions

1. Checkout this branch
2. Enable `tester_error_generator` with `drush en tester_error_generator`
1. Run `drush cr`
3. Run `drush tc`

You should get a result like so:

```
Crawling URLs
 -------------------------------------------------------------------------------- -------- -------- 
  Path                                                                             Status   Errors  
 -------------------------------------------------------------------------------- -------- -------- 
  https://domain.ddev.site/                                                        200      1       
                                                                                                    
   • User warning: Generate a warning in tester_error_generator_page_top()                          
  (line 16 of                                                                                       
  /var/www/html/web/modules/contrib/tester/modules/tester_error_generator/tester                    
  _error_generator.module)                                                                          
                                                                                                    
  https://domain.ddev.site/admin                                                   403      0       
  https://domain.ddev.site/foo-bar                                                 404      0       
 -------------------------------------------------------------------------------- -------- -------- 
```
