### PR TITLE
PHP-6: Update node plugin

### DIFF
--- a/src/Commands/TesterCommands.php
+++ b/src/Commands/TesterCommands.php
@@ -146,7 +146,7 @@ class TesterCommands extends DrushCommands {
       GLOBAL $base_url;
     }
 
-    $urls = $this->getUrls();
+    $urls = array_unique($this->getUrls());
 
     // We want to test 403 and 404 pages, so allow them.
     // See https://docs.guzzlephp.org/en/stable/request-options.html#http-errors

--- a/src/Commands/TesterCommands.php
+++ b/src/Commands/TesterCommands.php
@@ -206,7 +206,8 @@ class TesterCommands extends DrushCommands {
       $instance = $this->pluginManager->createInstance($id);
       $dependencies = $instance->dependencies();
       if ($this->isAllowed($dependencies)) {
-        $urls = array_merge($urls, $instance->urls());
+        // @todo Make the limit configurable.
+        $urls = array_merge($urls, $instance->urls(500));
       }
     }
 

--- a/src/Plugin/Tester/NodeTester.php
+++ b/src/Plugin/Tester/NodeTester.php
@@ -19,9 +19,16 @@ class NodeTester extends PluginBase implements TesterPluginInterface {
    * {@inheritdoc}
    */
   public function urls() {
-    return [
-      '/node',
-    ];
+    // @todo Figure out how to inject this service.
+    $storage = \Drupal::entityTypeManager()->getStorage('node');
+    $nodes = $storage->loadMultiple();
+
+    $urls = [];
+    foreach ($nodes as $node) {
+      $urls[] = $node->toUrl()->toString();
+    }
+
+    return $urls;
   }
 
   /**

--- a/src/Plugin/Tester/NodeTester.php
+++ b/src/Plugin/Tester/NodeTester.php
@@ -18,13 +18,16 @@ class NodeTester extends PluginBase implements TesterPluginInterface {
   /**
    * {@inheritdoc}
    */
-  public function urls() {
+  public function urls($limit) {
     // @todo Figure out how to inject this service.
     $storage = \Drupal::entityTypeManager()->getStorage('node');
     $nodes = $storage->loadMultiple();
 
     $urls = [];
     foreach ($nodes as $node) {
+      if (count($urls) > $limit) {
+        break;
+      }
       $urls[] = $node->toUrl()->toString();
     }
 

--- a/src/Plugin/Tester/NodeTester.php
+++ b/src/Plugin/Tester/NodeTester.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Drupal\tester\Plugin\Tester;
+
+use Drupal\Component\Plugin\PluginBase;
+use Drupal\tester\Plugin\TesterPluginInterface;
+
+/**
+ * Defines routes owned by the System module.
+ *
+ * @TesterPlugin(
+ *   id = "node",
+ * )
+ *
+ */
+class NodeTester extends PluginBase implements TesterPluginInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function urls() {
+    return [
+      '/node',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function dependencies() {
+    return [
+      'modules' => [
+        'node',
+        'user',
+      ],
+    ];
+  }
+
+}

--- a/src/Plugin/Tester/SystemTester.php
+++ b/src/Plugin/Tester/SystemTester.php
@@ -18,7 +18,7 @@ class SystemTester extends PluginBase implements TesterPluginInterface {
   /**
    * {@inheritdoc}
    */
-  public function urls() {
+  public function urls($limit) {
     return [
       '/',
       '/admin',

--- a/src/Plugin/TesterPluginInterface.php
+++ b/src/Plugin/TesterPluginInterface.php
@@ -9,10 +9,12 @@ interface TesterPluginInterface extends PluginInspectionInterface {
   /**
    * Returns an array of URLs for testing.
    *
+   * @param integer $limit
+   *   A maximum number of URLs to return.
    * @return array
    *   The URL path, with a leading slash (e.g. /node/3).
    */
-  public function urls();
+  public function urls($limit);
 
   /**
    * Returns an array of dependencies.


### PR DESCRIPTION
User story: [PHP-6: Update node plugin](https://palantir.atlassian.net/browse/PHP-6)

### Description

* Adds a node plugin
* Sets a default limit of 500 URLs per plugin.

### Testing instructions

1. Checkout this branch
1. Run `drush cr`
2. Run `drush tc`

You should get nodes in the list of output, like so:

```
Crawling URLs
 -------------------------------------------------------------------------------- -------- -------- 
  Path                                                                             Status   Errors  
 -------------------------------------------------------------------------------- -------- -------- 
  https://domain.ddev.site/node/1                                                  200      0       
  https://domain.ddev.site/about                                                   200      0       
  https://domain.ddev.site/node/3                                                  200      0       
  https://domain.ddev.site/node/4                                                  200      0       
  https://domain.ddev.site/node/5                                                  200      0    
```

